### PR TITLE
メール送信を行うかどうかの認証キーを保存するテーブルを用意する

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ApiKey extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'api_key',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'api_key',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'api_key' => 'hashed',
+    ];
+}

--- a/database/migrations/2023_12_07_232231_create_api_keys_table.php
+++ b/database/migrations/2023_12_07_232231_create_api_keys_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_keys', static function (Blueprint $table) {
+            $table->id();
+            $table->string('api_key')->unique()->comment('APIキー');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_keys');
+    }
+};


### PR DESCRIPTION
## 関連

- #3 

## 変更の概要

<!--
- 変更の概要を選択してください
- 複数選択可
 -->

-   [ ] フロントエンド
-   [x] バックエンド
-   [ ] 機能関連
-   [ ] バグ修正
-   [ ] リファクタリング
-   [ ] ドキュメント
-   [ ] その他

## 変更の詳細

**`app/Models/ApiKey.php`**

- `api_keys` モデルを作成

**`database/migrations/2023_12_07_232231_create_api_keys_table.php`**

- `api_keys` テーブルの作成

## 動作確認

- `php artisan migrate` でテーブルが作成できることを確認
- `php artisan migrate:rollback` でテーブルが削除されることを確認
- 作成したモデルクラスを利用してデータの挿入・取得ができることを確認

## その他

なし